### PR TITLE
Fix Gradle warning: use single-string notation for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ ext.buildSystemPath = "${System.env.VIVIDUS_BUILD_SYSTEM_HOME?:buildSystemRootDi
 apply from: "${buildSystemPath}/vividus-test-project.gradle"
 
 dependencies {
-    implementation platform(group: 'org.vividus', name: 'vividus-bom', version: '0.6.16')
-    implementation(group: 'org.vividus', name: 'vividus')
-    implementation(group: 'org.vividus', name: 'vividus-plugin-web-app')
+    implementation platform('org.vividus:vividus-bom:0.6.16')
+    implementation('org.vividus:vividus')
+    implementation('org.vividus:vividus-plugin-web-app')
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration with optimized dependency declarations. No impact on application functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->